### PR TITLE
Removed setDefaultK()

### DIFF
--- a/knn/knn.py
+++ b/knn/knn.py
@@ -64,10 +64,6 @@ knn = cv2.ml.KNearest_create();
 
 knn.setAlgorithmType(cv2.ml.KNEAREST_BRUTE_FORCE);
 
-# set default 3, can be changed at query time in predict() call
-
-knn.setDefaultK(3);
-
 # set up classification, turning off regression
 
 knn.setIsClassifier(True);


### PR DESCRIPTION
setDefaultK() does not affect calls to findNearest(), it only affects calls to predict() so it is redundant (and confusing) in this example.